### PR TITLE
bugfix

### DIFF
--- a/resources/public/js/cluster.js
+++ b/resources/public/js/cluster.js
@@ -1689,7 +1689,9 @@ function Cluster() {
         instances.forEach(function(instance) {
             if (instance.isMaster) {
                 getData("/api/recently-active-instance-recovery/" + instance.Key.Hostname + "/" + instance.Key.Port, function(recoveries) {
-                    if (!recoveries) {
+                    if (Array.isArray(recoveries) && recoveries.length === 0) {
+                        return
+                    } else if (typeof recoveries === 'object') {
                         return
                     }
                     // Result is an array: either empty (no active recovery) or with multiple entries
@@ -1780,7 +1782,9 @@ function Cluster() {
             });
         });
         getData("/api/recently-active-cluster-recovery/" + currentClusterName(), function(recoveries) {
-            if (!recoveries) {
+            if (Array.isArray(recoveries) && recoveries.length === 0) {
+                return
+            } else if (typeof recoveries === 'object') {
                 return
             }
             // Result is an array: either empty (no active recovery) or with multiple entries


### PR DESCRIPTION
cluster.js:1788 Uncaught TypeError: Cannot read properties of undefined (reading 'RecoveryEndTimestamp')
    at Object.success (cluster.js:1788:62)
    at j (jquery.min.js:2:27309)
    at Object.fireWith [as resolveWith] (jquery.min.js:2:28122)
    at x (jquery.min.js:5:22111)
    at XMLHttpRequest.b (jquery.min.js:5:26030)

cluster.js:1697 Uncaught TypeError: Cannot read properties of undefined (reading 'RecoveryEndTimestamp')
    at Object.success (cluster.js:1697:97)
    at j (jquery.min.js:2:27309)
    at Object.fireWith [as resolveWith] (jquery.min.js:2:28122)
    at x (jquery.min.js:5:22111)
    at XMLHttpRequest.b (jquery.min.js:5:26030)